### PR TITLE
Keep the Supabase service-role key server-side (it currently ships to the browser)

### DIFF
--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,10 +1,5 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 
 export async function GET() {
   try {

--- a/app/api/admin/library/route.ts
+++ b/app/api/admin/library/route.ts
@@ -1,18 +1,15 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
+import { NextResponse } from 'next/server';
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 
 export async function GET() {
-    const { data, error } = await supabase
-        .from("prompt_library")
-        .select("id, prompt_title, prompt_description, niche, likes, dislikes, created_at, created_by, users(name, email, image)")
-        .order("created_at", { ascending: false });
+  const { data, error } = await supabase
+    .from('prompt_library')
+    .select(
+      'id, prompt_title, prompt_description, niche, likes, dislikes, created_at, created_by, users(name, email, image)'
+    )
+    .order('created_at', { ascending: false });
 
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    return NextResponse.json(data);
+  return NextResponse.json(data);
 }

--- a/app/api/admin/most-used-prompts/route.ts
+++ b/app/api/admin/most-used-prompts/route.ts
@@ -1,33 +1,121 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from 'next/server';
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 import _ from 'lodash';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
 
 // Minimalist lexicon of English filler words to exclude from NLP category clustering
 const stopWords = new Set([
-  "about", "above", "after", "again", "against", "all", "and", "any", "are", "because", 
-  "been", "before", "being", "below", "between", "both", "but", "could", "did", "does",
-  "doing", "down", "during", "each", "few", "for", "from", "further", "had", "has",
-  "have", "having", "here", "how", "into", "more", "most", "once", "only", "other",
-  "ought", "our", "ours", "ourselves", "out", "over", "own", "same", "should", "some",
-  "such", "than", "that", "the", "their", "theirs", "them", "themselves", "then", "there",
-  "these", "they", "this", "those", "through", "too", "under", "until", "very", "was",
-  "were", "what", "when", "where", "which", "while", "who", "whom", "why", "with", "would",
-  "you", "your", "yours", "yourself", "yourselves", "generate", "create", "write", "make",
-  "tell", "give", "help", "please", "can", "will", "just", "like", "want", "need", "prompt", "code", "using"
+  'about',
+  'above',
+  'after',
+  'again',
+  'against',
+  'all',
+  'and',
+  'any',
+  'are',
+  'because',
+  'been',
+  'before',
+  'being',
+  'below',
+  'between',
+  'both',
+  'but',
+  'could',
+  'did',
+  'does',
+  'doing',
+  'down',
+  'during',
+  'each',
+  'few',
+  'for',
+  'from',
+  'further',
+  'had',
+  'has',
+  'have',
+  'having',
+  'here',
+  'how',
+  'into',
+  'more',
+  'most',
+  'once',
+  'only',
+  'other',
+  'ought',
+  'our',
+  'ours',
+  'ourselves',
+  'out',
+  'over',
+  'own',
+  'same',
+  'should',
+  'some',
+  'such',
+  'than',
+  'that',
+  'the',
+  'their',
+  'theirs',
+  'them',
+  'themselves',
+  'then',
+  'there',
+  'these',
+  'they',
+  'this',
+  'those',
+  'through',
+  'too',
+  'under',
+  'until',
+  'very',
+  'was',
+  'were',
+  'what',
+  'when',
+  'where',
+  'which',
+  'while',
+  'who',
+  'whom',
+  'why',
+  'with',
+  'would',
+  'you',
+  'your',
+  'yours',
+  'yourself',
+  'yourselves',
+  'generate',
+  'create',
+  'write',
+  'make',
+  'tell',
+  'give',
+  'help',
+  'please',
+  'can',
+  'will',
+  'just',
+  'like',
+  'want',
+  'need',
+  'prompt',
+  'code',
+  'using',
 ]);
 
 export async function GET() {
   try {
     // Fetch a solid sample of recent prompts to build the corpus
     const { data: prompts, error } = await supabase
-      .from("prompts")
-      .select("prompt_value")
-      .order("created_at", { ascending: false })
+      .from('prompts')
+      .select('prompt_value')
+      .order('created_at', { ascending: false })
       .limit(150);
 
     if (error) {
@@ -40,34 +128,37 @@ export async function GET() {
 
     // --- NLP Term Frequency Analysis ---
     // 1. Compile the corpus
-    const corpus = prompts.map(p => p.prompt_value).join(" ").toLowerCase();
-    
+    const corpus = prompts
+      .map((p) => p.prompt_value)
+      .join(' ')
+      .toLowerCase();
+
     // 2. Tokenize (extract words with 4+ letters)
     const tokens = corpus.match(/\b[a-z]{4,}\b/g) || [];
-    
+
     // 3. Filter stop words & normalize
-    const meaningfulTokens = tokens.filter(word => !stopWords.has(word));
-    
+    const meaningfulTokens = tokens.filter((word) => !stopWords.has(word));
+
     // 4. Cluster and count frequencies
     const frequencyMap = _.countBy(meaningfulTokens);
-    
+
     // 5. Sort to find the dominant trends
     const trendingCategories = Object.entries(frequencyMap)
       .map(([word, freq]) => ({
         domain: _.capitalize(word),
-        count: freq
+        count: freq,
       }))
       .sort((a, b) => b.count - a.count)
       .slice(0, 6); // Take top 6 categories matching our UI constraints
 
     // 6. Ensure we have data even if parsing failed
     if (trendingCategories.length === 0) {
-         trendingCategories.push({ domain: "General Processing", count: 1 });
+      trendingCategories.push({ domain: 'General Processing', count: 1 });
     }
 
     return NextResponse.json(trendingCategories);
   } catch (error) {
-    console.error("Critical error in trending NLP:", error);
-    return NextResponse.json([{ domain: "NLP Processing Error", count: 1 }], { status: 500 });
+    console.error('Critical error in trending NLP:', error);
+    return NextResponse.json([{ domain: 'NLP Processing Error', count: 1 }], { status: 500 });
   }
 }

--- a/app/api/admin/prompts-by-user/route.ts
+++ b/app/api/admin/prompts-by-user/route.ts
@@ -1,16 +1,9 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
+import { NextResponse } from 'next/server';
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 
 export async function GET() {
   // Fetch users along with the prompts they created
-  const { data, error } = await supabase
-    .from("users")
-    .select(`
+  const { data, error } = await supabase.from('users').select(`
       id,
       name,
       email,

--- a/app/api/admin/scores/route.ts
+++ b/app/api/admin/scores/route.ts
@@ -1,52 +1,49 @@
-import { NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
+import { NextResponse } from 'next/server';
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 
 export async function GET() {
-    // Fetch scores (last 100 to avoid huge payload)
-    const { data: scores, error: scoresError } = await supabase
-        .from("prompt_scores")
-        .select("id, prompt, clarity, specificity, model_fit, relevance, structure, conciseness, created_at")
-        .order("created_at", { ascending: false })
-        .limit(100);
+  // Fetch scores (last 100 to avoid huge payload)
+  const { data: scores, error: scoresError } = await supabase
+    .from('prompt_scores')
+    .select(
+      'id, prompt, clarity, specificity, model_fit, relevance, structure, conciseness, created_at'
+    )
+    .order('created_at', { ascending: false })
+    .limit(100);
 
-    if (scoresError) return NextResponse.json({ error: scoresError.message }, { status: 500 });
+  if (scoresError) return NextResponse.json({ error: scoresError.message }, { status: 500 });
 
-    // Calculate averages
-    let averages = {
-        clarity: 0,
-        specificity: 0,
-        model_fit: 0,
-        relevance: 0,
-        structure: 0,
-        conciseness: 0
-    };
+  // Calculate averages
+  let averages = {
+    clarity: 0,
+    specificity: 0,
+    model_fit: 0,
+    relevance: 0,
+    structure: 0,
+    conciseness: 0,
+  };
 
-    if (scores && scores.length > 0) {
-        scores.forEach(s => {
-            averages.clarity += s.clarity;
-            averages.specificity += s.specificity;
-            averages.model_fit += s.model_fit;
-            averages.relevance += s.relevance;
-            averages.structure += s.structure;
-            averages.conciseness += s.conciseness;
-        });
-
-        const count = scores.length;
-        averages.clarity /= count;
-        averages.specificity /= count;
-        averages.model_fit /= count;
-        averages.relevance /= count;
-        averages.structure /= count;
-        averages.conciseness /= count;
-    }
-
-    return NextResponse.json({
-        recentScores: scores,
-        averages
+  if (scores && scores.length > 0) {
+    scores.forEach((s) => {
+      averages.clarity += s.clarity;
+      averages.specificity += s.specificity;
+      averages.model_fit += s.model_fit;
+      averages.relevance += s.relevance;
+      averages.structure += s.structure;
+      averages.conciseness += s.conciseness;
     });
+
+    const count = scores.length;
+    averages.clarity /= count;
+    averages.specificity /= count;
+    averages.model_fit /= count;
+    averages.relevance /= count;
+    averages.structure /= count;
+    averages.conciseness /= count;
+  }
+
+  return NextResponse.json({
+    recentScores: scores,
+    averages,
+  });
 }

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!
-);
+import { supabaseAdmin as supabase } from '@/lib/supabase';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);

--- a/app/api/prompt-library/route.ts
+++ b/app/api/prompt-library/route.ts
@@ -1,64 +1,87 @@
-import { supabaseAdmin } from "@/lib/supabase";
-import { NextResponse } from "next/server";
-import { logActivityAndCalculateStreak } from "@/lib/streaks";
+import { supabaseAdmin } from '@/lib/supabase';
+import { NextResponse } from 'next/server';
+import { logActivityAndCalculateStreak } from '@/lib/streaks';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function POST(req: Request) {
-    try {
-        const { userId, title, description, promptText, niche } = await req.json();
-
-        if (!userId || !title || !description || !promptText || !niche) {
-            return NextResponse.json({
-                message: 'Missing Data'
-            }, { status: 400 });
-        }
-
-        // Save to db
-        await supabaseAdmin.from("prompt_library").insert({
-            created_by: userId,
-            prompt_title: title,
-            prompt_description: description,
-            promptText: promptText,
-            niche: niche,
-        });
-
-        // Update streak & log action
-        await logActivityAndCalculateStreak(userId, "prompt_library_added", { prompt: title });
-
-        return NextResponse.json({
-            message: 'Prompt Added to Library Saved Successfully'
-        }, {
-            status: 200
-        })
-    } catch (error) {
-        return NextResponse.json({ message: error }, { status: 500 });
-
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
-};
 
+    const { title, description, promptText, niche } = await req.json();
+
+    if (!title || !description || !promptText || !niche) {
+      return NextResponse.json(
+        {
+          message: 'Missing Data',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { data: user } = await supabaseAdmin
+      .from('users')
+      .select('id')
+      .eq('email', session.user.email)
+      .single();
+
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    // Save to db
+    await supabaseAdmin.from('prompt_library').insert({
+      created_by: user.id,
+      prompt_title: title,
+      prompt_description: description,
+      promptText: promptText,
+      niche: niche,
+    });
+
+    // Update streak & log action
+    await logActivityAndCalculateStreak(user.id, 'prompt_library_added', { prompt: title });
+
+    return NextResponse.json(
+      {
+        message: 'Prompt Added to Library Saved Successfully',
+      },
+      {
+        status: 200,
+      }
+    );
+  } catch (error) {
+    return NextResponse.json({ message: error }, { status: 500 });
+  }
+}
 
 export async function GET() {
-    try {
-        // Get data from DB with user details
-        const { data, error } = await supabaseAdmin
-            .from("prompt_library")
-            .select(`
+  try {
+    // Get data from DB with user details
+    const { data, error } = await supabaseAdmin
+      .from('prompt_library')
+      .select(
+        `
                 *,
                 users (
                     name,
                     username,
                     image
                 )
-            `)
-            .order("created_at", { ascending: false });
+            `
+      )
+      .order('created_at', { ascending: false });
 
-        if (error) {
-            console.error("Supabase error:", error.message);
-            return NextResponse.json({ error: error.message }, { status: 500 });
-        }
-
-        return NextResponse.json(data, { status: 200 });
-    } catch {
-        // console.error("Unexpected error:", error.message);
-        return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+    if (error) {
+      console.error('Supabase error:', error.message);
+      return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
+    return NextResponse.json(data, { status: 200 });
+  } catch {
+    // console.error("Unexpected error:", error.message);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
 }

--- a/app/api/prompt/[promptId]/route.ts
+++ b/app/api/prompt/[promptId]/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { supabaseAdmin } from '@/lib/supabase';
+
+async function getCurrentUserId(email: string): Promise<string | undefined> {
+  const { data } = await supabaseAdmin.from('users').select('id').eq('email', email).single();
+  return data?.id as string | undefined;
+}
+
+// GET /api/prompt/:promptId
+// Returns the base prompt plus its versions for the prompt editor, scoped to the
+// owner. Previously the editor read this directly with the service-role client
+// in the browser.
+export async function GET(_req: Request, { params }: { params: Promise<{ promptId: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const userId = await getCurrentUserId(session.user.email);
+    if (!userId) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { promptId } = await params;
+
+    const { data: prompt, error } = await supabaseAdmin
+      .from('prompts')
+      .select('id, prompt_value, created_at, created_by')
+      .eq('id', promptId)
+      .single();
+
+    if (error || !prompt) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    if (prompt.created_by !== userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const { data: versions } = await supabaseAdmin
+      .from('prompt_versions')
+      .select('*')
+      .eq('prompt_id', promptId)
+      .order('version_number', { ascending: false });
+
+    return NextResponse.json(
+      {
+        id: prompt.id,
+        prompt_value: prompt.prompt_value,
+        created_at: prompt.created_at,
+        versions: versions ?? [],
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Server Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// DELETE /api/prompt/:promptId — delete a prompt the signed-in user owns.
+// The delete is scoped by `created_by`, so a user can no longer delete another
+// user's prompt (the old client-side admin delete had no such check).
+export async function DELETE(_req: Request, { params }: { params: Promise<{ promptId: string }> }) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const userId = await getCurrentUserId(session.user.email);
+    if (!userId) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { promptId } = await params;
+
+    const { data, error } = await supabaseAdmin
+      .from('prompts')
+      .delete()
+      .eq('id', promptId)
+      .eq('created_by', userId)
+      .select('id');
+
+    if (error) {
+      console.error('Supabase error:', error.message);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    if (!data || data.length === 0) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (error) {
+    console.error('Server Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/prompts/route.ts
+++ b/app/api/prompts/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { supabaseAdmin } from '@/lib/supabase';
+
+// GET /api/prompts — list the signed-in user's saved prompts.
+// Replaces the previous client-side supabaseAdmin query, so the service-role
+// key no longer has to ship to the browser to power this page.
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: user } = await supabaseAdmin
+      .from('users')
+      .select('id')
+      .eq('email', session.user.email)
+      .single();
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('prompts')
+      .select('id, prompt_value, created_at')
+      .eq('created_by', user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      console.error('Supabase error:', error.message);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data ?? [], { status: 200 });
+  } catch (error) {
+    console.error('Server Error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/save-prompt-score/route.ts
+++ b/app/api/save-prompt-score/route.ts
@@ -1,33 +1,56 @@
-import {supabaseAdmin} from "@/lib/supabase";
-import { NextResponse } from "next/server";
+import { supabaseAdmin } from '@/lib/supabase';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 export async function POST(req: Request) {
-    try {
-        const { userId, prompt, clarity, specificity, model_fit, relevance, structure, conciseness } = await req.json();
-
-        if (!userId || !prompt) {
-            return NextResponse.json({
-                message: 'Missing Data'
-            }, { status: 400 });
-        }
-
-        await supabaseAdmin.from("prompt_scores").insert({
-            created_by: userId,
-            prompt,
-            clarity,
-            specificity,
-            model_fit,
-            relevance,
-            structure,
-            conciseness
-        });
-
-        return NextResponse.json({
-            message: 'Prompt Saved Successfully'
-        }, { status: 200 });
-
-    } catch (error) {
-        console.error('Server Error:', error);
-        return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
     }
+
+    const { prompt, clarity, specificity, model_fit, relevance, structure, conciseness } =
+      await req.json();
+
+    if (!prompt) {
+      return NextResponse.json(
+        {
+          message: 'Missing Data',
+        },
+        { status: 400 }
+      );
+    }
+
+    const { data: user } = await supabaseAdmin
+      .from('users')
+      .select('id')
+      .eq('email', session.user.email)
+      .single();
+
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    await supabaseAdmin.from('prompt_scores').insert({
+      created_by: user.id,
+      prompt,
+      clarity,
+      specificity,
+      model_fit,
+      relevance,
+      structure,
+      conciseness,
+    });
+
+    return NextResponse.json(
+      {
+        message: 'Prompt Saved Successfully',
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error('Server Error:', error);
+    return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+  }
 }

--- a/app/dashboard/all-prompts/page.tsx
+++ b/app/dashboard/all-prompts/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useUser } from '@/context/UserContext';
-import { supabaseAdmin } from '@/lib/supabase';
 import { useEffect, useState, useRef } from 'react';
 import { toast } from 'sonner';
 import gsap from 'gsap';
@@ -32,28 +31,15 @@ const Page = () => {
     const getPrompts = async () => {
       setLoading(true);
       try {
-        const { data: userData } = await supabaseAdmin
-          .from('users')
-          .select('id')
-          .eq('email', user?.email)
-          .single();
+        const res = await fetch('/api/prompts');
 
-        if (!userData) {
-          setLoading(false);
+        if (!res.ok) {
+          if (res.status !== 401) toast.error('Error fetching prompts');
+          setPrompts([]);
           return;
         }
 
-        const { data, error } = await supabaseAdmin
-          .from('prompts')
-          .select('id, prompt_value, created_at')
-          .eq('created_by', userData?.id)
-          .order('created_at', { ascending: false });
-
-        if (error) {
-          toast.error('Error fetching prompts');
-          return;
-        }
-
+        const data = await res.json();
         setPrompts(data || []);
       } catch (err) {
         console.error('Failed to load prompts:', err);
@@ -89,9 +75,9 @@ const Page = () => {
   const handleDelete = async () => {
     if (!deletePromptId) return;
 
-    const { error } = await supabaseAdmin.from('prompts').delete().eq('id', deletePromptId);
+    const res = await fetch(`/api/prompt/${deletePromptId}`, { method: 'DELETE' });
 
-    if (error) {
+    if (!res.ok) {
       toast.error('Error Deleting Prompt');
       return;
     }

--- a/app/dashboard/prompt/[id]/page.tsx
+++ b/app/dashboard/prompt/[id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useParams } from 'next/navigation';
 import { useEffect, useState, useCallback } from 'react';
-import { supabaseAdmin } from '@/lib/supabase';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -32,53 +31,45 @@ export default function PromptSessionPage() {
   } | null>(null);
 
   const fetchLatestVersion = useCallback(async () => {
-    // 1. Fetch base prompt details (created_at)
-    const { data: promptData } = await supabaseAdmin
-      .from('prompts')
-      .select('created_at')
-      .eq('id', id)
-      .single();
+    // Load the base prompt + its versions from the server (service-role stays
+    // server-side; the route is scoped to the prompt's owner).
+    const res = await fetch(`/api/prompt/${id}`);
 
-    // 2. Fetch all versions to determine newest and oldest
-    const { data: versions } = await supabaseAdmin
-      .from('prompt_versions')
-      .select('*')
-      .eq('prompt_id', id)
-      .order('version_number', { ascending: false });
+    if (!res.ok) {
+      setLoading(false);
+      return;
+    }
 
-    let latestModDate = promptData?.created_at;
+    const promptData: {
+      prompt_value: string | null;
+      created_at: string;
+      versions: PromptVersion[];
+    } = await res.json();
+
+    const versions = promptData.versions;
+    let latestModDate = promptData.created_at;
 
     if (versions && versions.length > 0) {
       const latest = versions[0];
       setCurrentVersion(latest);
       setEnhancedPrompt(latest.content);
-      latestModDate = latest.created_at;
-    } else {
+      latestModDate = latest.created_at ?? latestModDate;
+    } else if (promptData.prompt_value != null) {
       // Fallback: If no versions exist yet, load the original prompt
-      const { data: originalPrompt } = await supabaseAdmin
-        .from('prompts')
-        .select('prompt_value')
-        .eq('id', id)
-        .single();
-
-      if (originalPrompt) {
-        const fallbackVersion = {
-          version_number: 1,
-          source: 'Original Generation',
-          content: originalPrompt.prompt_value,
-          prompt_id: (Array.isArray(id) ? id[0] : id) as string,
-        };
-        setCurrentVersion(fallbackVersion);
-        setEnhancedPrompt(originalPrompt.prompt_value);
-      }
+      const fallbackVersion = {
+        version_number: 1,
+        source: 'Original Generation',
+        content: promptData.prompt_value,
+        prompt_id: (Array.isArray(id) ? id[0] : id) as string,
+      };
+      setCurrentVersion(fallbackVersion);
+      setEnhancedPrompt(promptData.prompt_value);
     }
 
-    if (promptData) {
-      setPromptMeta({
-        created_at: promptData.created_at,
-        last_modified: latestModDate,
-      });
-    }
+    setPromptMeta({
+      created_at: promptData.created_at,
+      last_modified: latestModDate,
+    });
 
     setLoading(false);
   }, [id]);
@@ -93,25 +84,23 @@ export default function PromptSessionPage() {
   const handleSave = async () => {
     setSaving(true);
 
-    const { data, error } = await supabaseAdmin
-      .from('prompt_versions')
-      .insert([
-        {
-          prompt_id: id,
-          content: enhancedPrompt,
-          source: 'user',
-          reason: 'User edited prompt in editor',
-        },
-      ])
-      .select()
-      .single();
+    const res = await fetch(`/api/prompt/${id}/versions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: enhancedPrompt,
+        source: 'user',
+        reason: 'User edited prompt in editor',
+      }),
+    });
 
-    if (!error) {
+    if (res.ok) {
+      const data = await res.json();
       alert(`New version created: v${data.version_number}`);
       // Refresh prompt meta and version info
       await fetchLatestVersion();
     } else {
-      console.error(error);
+      console.error('Failed to save new version');
     }
 
     setSaving(false);

--- a/app/prompt-library/page.tsx
+++ b/app/prompt-library/page.tsx
@@ -44,7 +44,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Badge } from '@/components/ui/badge';
 import { toast } from 'sonner';
-import { supabaseAdmin } from '@/lib/supabase';
 import { useSession } from 'next-auth/react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
@@ -178,18 +177,7 @@ export default function PromptLibrary() {
     const userEmail = session?.user?.email;
     if (!userEmail) return toast.error('User not logged in');
 
-    const { data: userData, error } = await supabaseAdmin
-      .from('users')
-      .select('id')
-      .eq('email', userEmail)
-      .single();
-
-    if (error || !userData) {
-      return toast.error('Failed to fetch user ID');
-    }
-
     const createdPrompt = {
-      userId: userData?.id,
       title: newPrompt?.title,
       description: newPrompt?.description,
       promptText: newPrompt?.promptText,

--- a/app/prompt-scoring/page.tsx
+++ b/app/prompt-scoring/page.tsx
@@ -4,7 +4,6 @@ import ScoreCard from '@/components/ScoreCard';
 import ScoringCriteria from '@/components/ScoringCriteria';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { supabaseAdmin } from '@/lib/supabase';
 import { useSession } from 'next-auth/react';
 import React, { useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -35,24 +34,12 @@ const Page = () => {
     const timer = setTimeout(async () => {
       if (!session?.user?.email || !prompt || !score) return;
 
-      const { data: userData, error } = await supabaseAdmin
-        .from('users')
-        .select('id')
-        .eq('email', session.user.email)
-        .single();
-
-      if (error || !userData) {
-        console.error('Failed to fetch user ID from Supabase: ', error);
-        return;
-      }
-
       const res = await fetch('/api/save-prompt-score', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          userId: userData.id,
           prompt: prompt,
           clarity: score?.criteriaScores?.clarity,
           specificity: score?.criteriaScores?.specificity,

--- a/components/recommendations/PromptRecommendation.tsx
+++ b/components/recommendations/PromptRecommendation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import debounce from 'lodash/debounce';
-import { supabase } from '@/lib/supabase';
+import { supabase } from '@/lib/supabaseClient';
 
 interface Props {
   promptId?: string; // filled after enhancement

--- a/lib/create-prompt-session.ts
+++ b/lib/create-prompt-session.ts
@@ -1,23 +1,23 @@
-import { supabase } from "./supabase";
+import { supabase } from './supabaseClient';
 
 export async function createPromptSession(userId: string, title: string) {
-    const { data, error } = await supabase
-        .from("prompt_sessions")
-        .insert([{ user_id: userId, title }])
-        .select()
-        .single();
-    if (error) throw error;
-    return data;
+  const { data, error } = await supabase
+    .from('prompt_sessions')
+    .insert([{ user_id: userId, title }])
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
 }
 
 export async function createPromptWithSession(userId: string, promptValue: string) {
-    const session = await createPromptSession(userId, promptValue.slice(0, 50));
-    const { data, error } = await supabase
-        .from("prompts")
-        .insert([{ prompt_value: promptValue, created_by: userId, session_id: session?.id }])
-        .select()
-        .single();
+  const session = await createPromptSession(userId, promptValue.slice(0, 50));
+  const { data, error } = await supabase
+    .from('prompts')
+    .insert([{ prompt_value: promptValue, created_by: userId, session_id: session?.id }])
+    .select()
+    .single();
 
-    if (error) throw error;
-    return { session, prompt: data };
-};
+  if (error) throw error;
+  return { session, prompt: data };
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,22 +1,22 @@
-import { createClient } from '@supabase/supabase-js'
+import 'server-only';
+import { createClient } from '@supabase/supabase-js';
+
+// Server-only service-role (admin) client. The `server-only` import above makes
+// the build fail if this module is ever pulled into a Client Component bundle,
+// which is what keeps the service-role key out of the browser. The key is read
+// from a non-public env var (NOT NEXT_PUBLIC_*) so it is never inlined into
+// client code. The anon client for the browser lives in `lib/supabaseClient.ts`.
 
 let supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-let supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-let supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!;
+let supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
 
 if (process.env.NODE_ENV !== 'production') {
-  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL_TEST!,
-  supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY_TEST!,
-  supabaseServiceKey = process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY_TEST!
+  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL_TEST!;
+  supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY_TEST!;
 }
-
-// console.log('Node Environment: ', process.env.NODE_ENV);
-
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey, {
   auth: {
-    persistSession: false
-  }
+    persistSession: false,
+  },
 });

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@supabase/supabase-js';
+
+// Anon (public) Supabase client. Safe to import from Client Components — it uses
+// the public anon key and every request is still constrained by your RLS
+// policies. The service-role client lives in `lib/supabase.ts`, which is
+// server-only so its key can never reach the browser.
+
+let supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+let supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+if (process.env.NODE_ENV !== 'production') {
+  supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL_TEST!;
+  supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY_TEST!;
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "rehype-highlight": "^7.0.2",
         "remark": "^15.0.1",
         "remark-gfm": "^4.0.1",
+        "server-only": "^0.0.1",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
@@ -14363,6 +14364,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "rehype-highlight": "^7.0.2",
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.1",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## What this fixes

The Supabase **service-role key** currently ships to the browser, which lets any visitor bypass every RLS policy in the project.

Two things combine to cause it:

1. `lib/supabase.ts` reads the key from **`NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY`**. The `NEXT_PUBLIC_` prefix inlines the value into the client bundle.
2. `supabaseAdmin` (the service-role client) is imported directly into four **Client Components**:
   - `app/dashboard/all-prompts/page.tsx`
   - `app/dashboard/prompt/[id]/page.tsx`
   - `app/prompt-library/page.tsx`
   - `app/prompt-scoring/page.tsx`

So the key is both marked public *and* pulled into client bundles. Anyone can open DevTools, read the `service_role` JWT out of a dashboard chunk, and use it to read/write every table regardless of RLS.

This is the same issue I emailed you about — sending the PR as you asked.

## The fix

**Keep the service-role client on the server, and stop trusting the client for identity.** I kept the change surgical (20 files) so the security-relevant parts are easy to review.

- **`lib/supabase.ts`** now holds only the service-role (`supabaseAdmin`) client. It is guarded by `import 'server-only'` and reads the key from a non-public **`SUPABASE_SERVICE_ROLE_KEY`**. If anything ever imports it into a client bundle again, the build fails instead of silently leaking the key. Every existing server-side importer of `supabaseAdmin` keeps working unchanged.
- **New `lib/supabaseClient.ts`** holds the anon client, which is safe on the client (public anon key, still bound by RLS). The two files that used the anon client (`components/recommendations/PromptRecommendation.tsx`, `lib/create-prompt-session.ts`) now import it from here.
- **Six `app/api/admin/*` routes** (`analytics`, `library`, `most-used-prompts`, `prompts-by-user`, `scores`, `users`) were each constructing their own `createClient(url, process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!)` inline. They now use the shared server-only `supabaseAdmin`. After this PR, **`NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY` is referenced nowhere in the codebase**, which is what makes it safe to delete the public var.
- **The four Client Components** no longer touch `supabaseAdmin`. They call server routes instead:
  - `GET /api/prompts` (new) — lists the signed-in user's prompts
  - `GET /api/prompt/[promptId]` (new) — base prompt + versions for the editor, scoped to the owner
  - `DELETE /api/prompt/[promptId]` (new) — delete a prompt you own
  - `POST /api/save-prompt-score` and `POST /api/prompt-library` now resolve the user from the **NextAuth session** instead of accepting a `userId` from the request body.

The user is now derived from the session on the server in every one of these paths, so the browser never needs the admin key to answer "who am I."

### Bonus: an access-control bug fixed along the way

The old client-side delete was `supabaseAdmin.from('prompts').delete().eq('id', deletePromptId)` with **no ownership check** — using the admin client, that means anyone could delete anyone's prompt by id. The new `DELETE /api/prompt/[promptId]` scopes the delete with `.eq('created_by', <session user>)`, so you can only delete your own. The new `GET /api/prompt/[promptId]` is owner-scoped too.

## Action required after merging

1. **Rotate the Supabase service-role key.** It has been in the public client bundle, so treat it as compromised.
2. Set the rotated key as **`SUPABASE_SERVICE_ROLE_KEY`** (and `SUPABASE_SERVICE_ROLE_KEY_TEST` for non-prod) in your environment / Vercel project settings. Remove the old `NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY`.
3. Redeploy.

(Separately, and outside this PR: `prod_dump_with_data.sql` has real user emails committed — worth scrubbing from history.)

## Testing

- `npx tsc --noEmit` — passes.
- `next build` — compiles, all 52 pages generated.
- `grep` confirms no Client Component imports `supabaseAdmin`, no client imports the `server-only` module, and `NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY` appears nowhere.

Adds one dependency: [`server-only`](https://www.npmjs.com/package/server-only) (a tiny, standard Vercel package used as the build-time guard).
